### PR TITLE
fix: link miss

### DIFF
--- a/client/components/TheProducts.vue
+++ b/client/components/TheProducts.vue
@@ -153,7 +153,7 @@
             <v-btn
               flat
               color="cyan"
-              href="https://github.com/mnao305/mai-score"
+              href="https://github.com/mnao305/exbeak"
               target="_blank"
               rel="noopener"
             >


### PR DESCRIPTION
fix: #71 
exbeakのGitHubのリンク間違いを直した